### PR TITLE
Fixed broken link

### DIFF
--- a/content/pages/philosphy.md
+++ b/content/pages/philosphy.md
@@ -35,4 +35,4 @@ Camera particularly with these builds. See [the tools page](/tools) for possible
 
 ## Finally...
 
-We don't hold a monopoly on LI builds here at Accessibility Wars. [Check out some possible alternatives](/pages/alternatives)
+We don't hold a monopoly on LI builds here at Accessibility Wars. [Check out some possible alternatives](/alternatives)


### PR DESCRIPTION
Check out some possible alternatives was linked to https://aw2.help/pages/alternatives instead of https://aw2.help/alternatives